### PR TITLE
Create users endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,62 @@ Install Intellij CE: https://www.jetbrains.com/idea/download/#section=mac
 
 Once Intellij is up go to plugins and download Scala and SBT.
 
+Install Cassandra:
+1. brew install python
+2. pip install cql
+3. brew install cassandra
+
 # Commands
+
 sbt run
+
 sbt test
+
 sbt scalastyle
+
+sbt docker:publishLocal
+
+docker run \
+--rn \
+-p 8080:8080 \
+shoe-dawg-backend:1.0
+
+brew services start cassandra
+
+cqlsh
+
+[nodetool](http://cassandra.apache.org/doc/latest/tools/nodetool/nodetool.html)
+
+# Endpoints
+
+GET /api/login
+```
+$ curl -i -u email:password http://localhost:8080/api/login
+
+HTTP/1.1 200 OK
+Set-Authorization: 86A1D2715C78BC49DE0793A220F0565D9A967E7F-DFEEBEC80A127894237CF350056CF24D7D7546A7CFB68D0C39C3DA61DA8BFB4B
+Server: akka-http/10.1.0
+Date: Thu, 26 Apr 2018 13:58:10 GMT
+Content-Length: 0
+```
+
+POST /api/logout
+```
+$ curl -i -X POST -H 'Authorization: 86A1D2715C78BC49DE0793A220F0565D9A967E7F-DFEEBEC80A127894237CF350056CF24D7D7546A7CFB68D0C39C3DA61DA8BFB4B' http://localhost:8080/api/logout
+
+HTTP/1.1 200 OK
+Set-Authorization:
+Server: akka-http/10.1.0
+Date: Thu, 26 Apr 2018 13:59:53 GMT
+Content-Length: 0
+```
+
+POST /api/users
+```
+$ curl -i -X POST -H 'Content-Type: application/json' -d '{"email":"email", "password":"password"}' http://localhost:8080/api/users
+
+HTTP/1.1 201 Created
+Server: akka-http/10.1.0
+Date: Thu, 26 Apr 2018 14:01:49 GMT
+Content-Length: 0
+```

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
 name := "shoe-dawg-backend"
 version := "1.0"
 scalaVersion := "2.12.5"
+dockerBaseImage := "openjdk:jre-alpine"
 
 libraryDependencies ++= {
   val akkaV = "2.5.11"
@@ -17,7 +18,14 @@ libraryDependencies ++= {
     "com.softwaremill.akka-http-session" %% "core" % "0.5.3" exclude("com.typesafe.akka", "akka-http"),
     "com.typesafe" % "config" % "1.3.2",
     "com.lightbend.akka" %% "akka-stream-alpakka-cassandra" % "0.18",
+    "com.github.t3hnar" %% "scala-bcrypt" % "3.1",
     "org.scalatest" %% "scalatest" % scalaTestV % Test,
     "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpV % Test
+//    "org.mockito" % "mockito-all" % "1.8.4"
   )
 }
+
+
+enablePlugins(JavaAppPackaging)
+enablePlugins(DockerPlugin)
+enablePlugins(AshScriptPlugin)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.4")

--- a/src/main/scala/CassandraClient.scala
+++ b/src/main/scala/CassandraClient.scala
@@ -1,31 +1,132 @@
-import com.datastax.driver.core.Cluster
+import com.datastax.driver.core._
+import com.google.common.util.concurrent.{FutureCallback, Futures, ListenableFuture}
 import com.typesafe.config.Config
+import com.typesafe.scalalogging.LazyLogging
+import org.mindrot.jbcrypt.BCrypt
+
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.language.implicitConversions
 
 
-class CassandraClient(config: Config) {
+object CassandraUtils {
+  // Convert Java ListenableFuture to Scala Future
+  // Source: https://www.beyondthelines.net/databases/querying-cassandra-from-scala/
+  implicit def listenableFutureToFuture[T](listenableFuture: ListenableFuture[T]): Future[T] = {
+    val promise = Promise[T]()
+    Futures.addCallback(listenableFuture, new FutureCallback[T] {
+      def onFailure(error: Throwable): Unit = {
+        promise.failure(error)
+        ()
+      }
+
+      def onSuccess(result: T): Unit = {
+        promise.success(result)
+        ()
+      }
+    })
+    promise.future
+  }
+
+  implicit class CqlStrings(val context: StringContext) extends AnyVal {
+    def cql(args: Any*)(implicit session: Session): Future[PreparedStatement] = {
+      val statement = new SimpleStatement(context.raw(args: _*))
+      session.prepareAsync(statement)
+    }
+  }
+
+  def execute(statement: Future[BoundStatement], params: Any*)(
+    implicit executor: ExecutionContext, session: Session
+  ): Future[ResultSet] = statement
+    .flatMap(session.executeAsync(_))
+//    .map(_.bind(params.map(_.asInstanceOf[Object]))) // Cant figure out how to map array buffer to cql data type varchar (needs a custom codec)
+
+  def parseOne(resultSet: ResultSet): Option[Row] = Option(resultSet.one())
+}
+
+class CassandraClient(config: Config) extends LazyLogging {
+  import CassandraUtils._
+
+  private val keyspace = config.getString("cassandra.keyspace")
   private val cluster = Cluster.builder
     .addContactPoint(config.getString("cassandra.hostname"))
     .withPort(config.getInt("cassandra.port"))
     .build()
-  private val session = cluster.connect()
+  private implicit val executionContext = ExecutionContext.global
+  private implicit val session = cluster.connect()
 
-  def apply(statement: String) = {
-    session.execute(statement)
-  }
-
-//  https://github.com/magro/play2-scala-cassandra-sample/blob/master/app/models/Cassandra.scala
   def seed(): Unit = {
-    val keyspace = config.getString("cassandra.keyspace")
-    session.execute(s"CREATE KEYSPACE IF NOT EXISTS $keyspace WITH replication = {'class': 'NetworkTopologyStrategy', 'DC1': 3} AND durable_writes = true;")
-    session.execute(s"CREATE TABLE IF NOT EXISTS $keyspace.users (" +
-      s"id uuid PRIMARY KEY," +
-      s"email text," +
-      s"password_salt text," +
-      s"password_hash text);")
+    logger.info(s"CREATE KEYSPACE IF NOT EXISTS $keyspace")
+    session.execute(s"CREATE KEYSPACE IF NOT EXISTS $keyspace WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 1} AND durable_writes = true;")
+    logger.info(s"CREATE TABLE IF NOT EXISTS $keyspace.users")
+    session.execute(s"CREATE TABLE IF NOT EXISTS $keyspace.users (email text PRIMARY KEY, password_hash text);")
   }
 
   def close(): Unit = {
-    cluster.close()
     session.close()
+    cluster.close()
+  }
+
+  // WARNING: DANGER
+  def flush(yes: Boolean = false): Unit = {
+    val tables = Seq("users")
+    tables.foreach { table =>
+      logger.info(s"TRUNCATE TABLE $keyspace.$table ($yes)")
+      if (yes) {
+        session.execute(s"TRUNCATE TABLE $keyspace.$table")
+      }
+    }
+  }
+
+  // WARNING: DANGER
+  def cleanUp(yes: Boolean = false): Unit = {
+    logger.info(s"DROP KEYSPACE IF EXISTS $keyspace ($yes)")
+    if (yes) {
+      session.execute(s"DROP KEYSPACE IF EXISTS $keyspace")
+    }
+  }
+
+  def insertUser(email: String, password: String): Future[ResultSet] = {
+    val passwordHash = BCrypt.hashpw(password, BCrypt.gensalt(10))
+    execute(cql"INSERT INTO $keyspace.users(email, password_hash) VALUES (?, ?) IF NOT EXISTS"
+      .map(_.bind(email, passwordHash)))
+  }
+
+  def selectUser(email: String): Future[Option[User]] = {
+    for {
+      resultSet <- execute(cql"SELECT * FROM $keyspace.users WHERE email = ? LIMIT 1".map(_.bind(email)))
+      row = parseOne(resultSet)
+    } yield {
+      row.map(buildUser)
+    }
+  }
+
+//  def selectUserHash(email: String): Future[Option[String]] = {
+//    for {
+//      resultSet <- execute(cql"SELECT password_hash FROM $keyspace.users WHERE email = ? LIMIT 1".map(_.bind(email)))
+
+//      row = parseOne(resultSet)
+//    } yield {
+//      row.map(_.getString("password_hash"))
+//    }
+//  }
+//
+//  def selectUser(email: String, password: String): Future[Option[User]] = {
+//    val passwordHashF = selectUserHash(email)
+//    val query = cql"SELECT email, password_hash FROM $keyspace.users WHERE email = ? AND password_hash = ? LIMIT 1 ALLOW FILTERING"
+//    passwordHashF.flatMap({
+//      case Some(passwordHash) => for {
+//          resultSet <- execute(query.map(_.bind(email, passwordHash)))
+//          row = parseOne(resultSet)
+//        } yield {
+//          row.map(buildUser)
+//        }
+//      case None => Future(None)
+//    })
+//  }
+
+  private def buildUser(r: Row): User = {
+    val email = r.getString("email")
+    val passwordHash = r.getString("password_hash")
+    User(email, passwordHash)
   }
 }

--- a/src/main/scala/CustomDirectives.scala
+++ b/src/main/scala/CustomDirectives.scala
@@ -1,0 +1,38 @@
+import akka.http.scaladsl.model.headers.{BasicHttpCredentials, HttpChallenges}
+import akka.http.scaladsl.server.directives._
+import akka.http.scaladsl.util.FastFuture._
+
+import scala.concurrent.Future
+
+
+trait CustomDirectives {
+  import BasicDirectives._
+  import SecurityDirectives._
+
+  //#authenticator
+  /**
+    * @group security
+    */
+  type CustomAsyncAuthenticator[T] = (String, String) ⇒ Future[Option[T]]
+
+  /**
+    * Wraps the inner route with Http Basic authentication support.
+    * The given authenticator determines whether the credentials in the request are valid
+    * and, if so, which user object to supply to the inner route.
+    *
+    * @group security
+    */
+  def customAuthenticateBasicAsync[T](realm: String, authenticator: CustomAsyncAuthenticator[T]): AuthenticationDirective[T] = {
+    val failure = AuthenticationResult.failWithChallenge(HttpChallenges.basic(realm))
+    extractExecutionContext.flatMap { implicit ec ⇒
+      authenticateOrRejectWithChallenge[BasicHttpCredentials, T] {
+        case Some(BasicHttpCredentials(email, password)) =>
+          authenticator(email, password).fast.map {
+            case Some(t) => AuthenticationResult.success(t)
+            case None => failure
+          }
+        case None => Future(failure)
+      }
+    }
+  }
+}

--- a/src/main/scala/JsonSupport.scala
+++ b/src/main/scala/JsonSupport.scala
@@ -1,10 +1,12 @@
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
-import spray.json.{DefaultJsonProtocol, RootJsonFormat}
+import spray.json.DefaultJsonProtocol
 
 
 // Domain models
-final case class Shoe(name: String)
+case class Shoe(name: String)
+case class User(email: String, password: String)
 
 trait JsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
-  implicit val shoeFormat: RootJsonFormat[Shoe] = jsonFormat1(Shoe)
+  implicit val shoeFormat = jsonFormat1(Shoe)
+  implicit val userFormat = jsonFormat2(User)
 }

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -1,3 +1,9 @@
 akka.http.session {
   server-secret = c05ll3lesrinf39t7mc5h6un6r0c69lgfno69dsak3vabeqamouq4328cuaekros401ajdpkh60rrtpd8ro24rbuqmgtnd1ebag6ljnb65i8a55d482ok7o0nch0bfbe
 }
+
+cassandra {
+  hostname = "127.0.0.1"
+  port = 9042
+  keyspace = "test"
+}

--- a/src/test/scala/CassandraClientSpec.scala
+++ b/src/test/scala/CassandraClientSpec.scala
@@ -1,0 +1,48 @@
+import com.typesafe.config.ConfigFactory
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FlatSpec, Matchers}
+
+import scala.concurrent.{Await, ExecutionContext}
+import scala.concurrent.duration.Duration
+
+
+class CassandraClientSpec extends FlatSpec
+  with Matchers with BeforeAndAfter with BeforeAndAfterAll with JsonSupport {
+  private val config = ConfigFactory.load()
+  private implicit val cassandraClient = new CassandraClient(config)
+  private implicit val executor = ExecutionContext.global
+
+  val email = "email"
+  val password = "password"
+
+  override def beforeAll {
+    cassandraClient.cleanUp(yes = true)
+    cassandraClient.seed()
+  }
+
+  override def afterAll {
+    cassandraClient.close()
+  }
+
+  before {
+    cassandraClient.flush(yes = true)
+  }
+
+
+  behavior of "selectUser"
+
+  it should "fail to retrieve non-existent user" in {
+    val f = cassandraClient.selectUser(email)
+    val user = Await.result(f, Duration.Inf)
+
+    user shouldBe None
+  }
+
+  it should "query cassandra for correct user given email and password" in {
+    val f = cassandraClient.insertUser(email, password).flatMap { r =>
+      cassandraClient.selectUser(email)
+    }
+    val user = Await.result(f, Duration.Inf)
+
+    user shouldBe a [Some[_]]
+  }
+}

--- a/src/test/scala/WebServerSpec.scala
+++ b/src/test/scala/WebServerSpec.scala
@@ -1,32 +1,73 @@
-import org.scalatest.{FlatSpec, Matchers}
-import akka.http.scaladsl.model.ContentTypes.`application/json`
-import akka.http.scaladsl.model.StatusCodes._
-import akka.http.scaladsl.server.AuthorizationFailedRejection
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FlatSpec, Matchers}
+import akka.http.scaladsl.model.ContentTypes._
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.headers._
+import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 
 
-class WebServerSpec extends FlatSpec with Matchers with ScalatestRouteTest with SessionTestUtils {
+class WebServerSpec extends FlatSpec
+  with Matchers with ScalatestRouteTest with SessionTestUtils with JsonSupport with BeforeAndAfter with BeforeAndAfterAll {
+  private implicit val cassandraClient = new CassandraClient(config)
   private val app = new WebServer(config)
   private val routes = app.createRoutes
+
+  val email = "email"
+  val password = "password"
+  val user = User(email, password)
+  val validCredentials = BasicHttpCredentials(email, password)
+
+  override def beforeAll {
+    cassandraClient.cleanUp(yes = true)
+    cassandraClient.seed()
+  }
+
+  override def afterAll {
+    cassandraClient.close()
+    cleanUp() // shutdown actor system used by ScalatestRouteTest
+  }
+
+  before {
+    cassandraClient.flush(yes = true)
+  }
 
 
   behavior of "pathSingleSlash"
 
   it should "return json response" in {
    Get() ~> routes ~> check {
-     status shouldBe OK
+     status shouldBe StatusCodes.OK
      contentType shouldBe `application/json`
    }
   }
 
 
+  behavior of "non-existent path"
+
+  it should "return not found" in {
+    Get("/missing") ~> Route.seal(routes) ~> check {
+      status shouldBe StatusCodes.NotFound
+    }
+  }
+
+
   behavior of "login"
 
-  it should "respond with 200" in {
-    Post("/api/login") ~> routes ~> check {
-      status shouldBe OK
-      SessionTestUtils.getSessionToken shouldBe 'defined
-      SessionTestUtils.sessionIsExpired shouldBe false
+  it should "respond with 200 if user exists" in {
+    Post("/api/users", user) ~> routes ~> check {
+      status shouldBe StatusCodes.Created
+
+      Get("/api/login") ~> addCredentials(validCredentials) ~> routes ~> check {
+        status shouldBe StatusCodes.OK
+        SessionTestUtils.getSessionToken shouldBe 'defined
+        SessionTestUtils.sessionIsExpired shouldBe false
+      }
+    }
+  }
+
+  it should "respond with 401 if user does not exist" in {
+    Get("/api/login") ~> addCredentials(validCredentials) ~> Route.seal(routes) ~> check {
+      status shouldEqual StatusCodes.Unauthorized
     }
   }
 
@@ -34,29 +75,38 @@ class WebServerSpec extends FlatSpec with Matchers with ScalatestRouteTest with 
   behavior of "logout"
 
   it should "respond with bad request with no session token" in {
-    Post("/api/logout") ~> routes ~> check {
-      rejection shouldBe AuthorizationFailedRejection
+    Post("/api/logout") ~> Route.seal(routes) ~> check {
+      status shouldEqual StatusCodes.Forbidden
     }
   }
 
   it should "get session token and respond with 200" in  {
-    Post("/api/login") ~> routes ~> check {
-      val Some(sessionToken) = SessionTestUtils.getSessionToken
+    Post("/api/users", user) ~> routes ~> check {
+      status shouldBe StatusCodes.Created
 
-      Post("/api/logout") ~> addHeader(SessionTestUtils.setSessionHeader(sessionToken)) ~> routes ~> check {
-        status shouldBe OK
-        SessionTestUtils.sessionIsExpired shouldBe true
+      Get("/api/login") ~> addCredentials(validCredentials) ~> routes ~> check {
+        val Some(sessionToken) = SessionTestUtils.getSessionToken
+
+        Post("/api/logout") ~> addHeader(SessionTestUtils.setSessionHeader(sessionToken)) ~> routes ~> check {
+          status shouldBe StatusCodes.OK
+          SessionTestUtils.sessionIsExpired shouldBe true
+        }
       }
     }
   }
 
   it should "use tampered session and respond with bad request" in {
-    Post("/api/login") ~> routes ~> check {
-      val Some(sessionToken) = SessionTestUtils.getSessionToken
-      val tamperedSession = sessionToken + "tampered"
+    Post("/api/users", user) ~> routes ~> check {
+      status shouldBe StatusCodes.Created
 
-      Post("/api/logout") ~> addHeader(SessionTestUtils.setSessionHeader(tamperedSession)) ~> routes ~> check {
-        rejection shouldBe AuthorizationFailedRejection
+      Get("/api/login") ~> addCredentials(validCredentials) ~> routes ~> check {
+        val Some(sessionToken) = SessionTestUtils.getSessionToken
+        val tamperedSession = sessionToken + "tampered"
+
+        Post("/api/logout") ~> addHeader(SessionTestUtils.setSessionHeader(tamperedSession)) ~> Route.seal(routes) ~> check {
+          status shouldEqual StatusCodes.Forbidden
+          responseAs[String] shouldEqual "The supplied authentication is not authorized to access this resource"
+        }
       }
     }
   }
@@ -65,30 +115,53 @@ class WebServerSpec extends FlatSpec with Matchers with ScalatestRouteTest with 
   behavior of "current_login"
 
   it should "respond with bad request with no session token" in {
-    Get("/api/current_login") ~> routes ~> check {
-      rejection shouldBe AuthorizationFailedRejection
+    Get("/api/current_login") ~> Route.seal(routes) ~> check {
+      status shouldEqual StatusCodes.Forbidden
     }
   }
 
   it should "get session token and respond with 200" in  {
-    Post("/api/login") ~> routes ~> check {
-      val Some(sessionToken) = SessionTestUtils.getSessionToken
+    Post("/api/users", user) ~> routes ~> check {
+      status shouldBe StatusCodes.Created
 
-      Get("/api/current_login") ~> addHeader(SessionTestUtils.setSessionHeader(sessionToken)) ~> routes ~> check {
-        status shouldBe OK
-        SessionTestUtils.sessionIsExpired shouldBe false
+      Get("/api/login") ~> addCredentials(validCredentials) ~> routes ~> check {
+        val Some(sessionToken) = SessionTestUtils.getSessionToken
+
+        Get("/api/current_login") ~> addHeader(SessionTestUtils.setSessionHeader(sessionToken)) ~> routes ~> check {
+          status shouldBe StatusCodes.OK
+          SessionTestUtils.sessionIsExpired shouldBe false
+        }
       }
     }
   }
 
   it should "use tampered session and respond with bad request" in {
-    Post("/api/login") ~> routes ~> check {
-      val Some(sessionToken) = SessionTestUtils.getSessionToken
-      val tamperedSession = sessionToken + "tampered"
+    Post("/api/users", user) ~> routes ~> check {
+      status shouldBe StatusCodes.Created
 
-      Get("/api/current_login") ~> addHeader(SessionTestUtils.setSessionHeader(tamperedSession)) ~> routes ~> check {
-        rejection shouldBe AuthorizationFailedRejection
+      Get("/api/login") ~> addCredentials(validCredentials) ~> routes ~> check {
+        val Some(sessionToken) = SessionTestUtils.getSessionToken
+        val tamperedSession = sessionToken + "tampered"
+
+        Get("/api/current_login") ~> addHeader(SessionTestUtils.setSessionHeader(tamperedSession)) ~> Route.seal(routes) ~> check {
+          status shouldEqual StatusCodes.Forbidden
+        }
       }
+    }
+  }
+
+
+  behavior of "POST users"
+
+  it should "take email and password and store salt and hashed password" in {
+    Post("/api/users", user) ~> routes ~> check {
+      status shouldBe StatusCodes.Created
+    }
+  }
+
+  it should "fail when missing either email or password" in {
+    Post("/api/users", User("", "password")) ~> routes ~> check {
+      status shouldBe StatusCodes.BadRequest
     }
   }
 }


### PR DESCRIPTION
[X] Write helper to minimze boilerplate reading/writing to cassandra
[X] Create salt and password hash
[X] Persist user email and password hash
[X] Test endpoint for user creation
[X] Authenticate basic async when user POSTS /login

Resources:
1. https://www.cakesolutions.net/teamblogs/2013/07/31/akka-cassandra-activator
2. https://github.com/t3hnar/scala-bcrypt/tree/e960ff98b00f405d18338088fb6e2489cee242af
3. https://doc.akka.io/docs/akka-http/current/routing-dsl/exception-handling.html#default-exception-handler
4. http://danielwestheide.com/blog/2012/12/19/the-neophytes-guide-to-scala-part-5-the-option-type.html
5. https://d1.awsstatic.com/whitepapers/Cassandra_on_AWS.pdf
6. http://cassandra.apache.org/doc/latest/cql/ddl.html#use